### PR TITLE
ci: verify preinstall pnpm-guard fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,5 @@ If you would like to help take a look at the [list of issues](https://github.com
 ## License
 
 The anolilab monorepo-template is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT)
+
+<!-- CI verification for preinstall fix (commit 2817700) -->


### PR DESCRIPTION
Verification PR to exercise the Tests and Lint workflows after fixing the preinstall pnpm enforcement guard (commit 2817700 on main).

The preinstall guard previously ran `npx only-allow pnpm`, which failed on every install because npx resets the npm context and pnpm v11 no longer sets npm_config_user_agent during preinstall. This broke all test-matrix and lint jobs at the install step. The guard now detects pnpm via npm_execpath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)